### PR TITLE
日付変更処理エラーの対策等

### DIFF
--- a/ERB/6-日付変更時処理/1-日付変更時及びキャラ専用イベント.ERB
+++ b/ERB/6-日付変更時処理/1-日付変更時及びキャラ専用イベント.ERB
@@ -967,15 +967,16 @@ RETURNF 0
 
 FOR LCOUNT, 0, 3
 	豹変フラグ = 0
-	SIF LCOUNT == 0
-		対象 = TARGET
-	SIF LCOUNT == 1
-		対象 = MASTER
-	IF LCOUNT == 2
-		SIF ASSI == -1
-			BREAK
-		対象 = ASSI
-	ENDIF
+	SELECTCASE LCOUNT
+		CASE 0
+			対象 = TARGET
+		CASE 1
+			対象 = MASTER
+		CASE 2
+			対象 = ASSI
+	ENDSELECT
+	SIF 対象 == -1
+		CONTINUE
 
 	IF オン && 豹変可能(対象) && !TRANCEFLAG:対象:豹変中
 		;キャラごとの条件を設定


### PR DESCRIPTION
恐らく「調教対象なし」時に日をまたぐとエラーが出る問題の修正案

「助手なし」だけ分岐させるより「対象 == -1」でCONTINUEさせる方が単純で見通し良くなる気がするので