### PR TITLE
CSVエディタでの既存CSV呼び出し時に性別を強制決定しないように修正

### DIFF
--- a/ERB/3-キャラステータス,購入,売却,生成/3-キャラマニュアル,キャラ購入処理.ERB
+++ b/ERB/3-キャラステータス,購入,売却,生成/3-キャラマニュアル,キャラ購入処理.ERB
@@ -361,7 +361,7 @@ SIF CSTR:種族 == ""
 SIF CSTR:英語名 == ""
 	DEBUGPRINTFORML %NAME:TARGET%に英語名が設定されてない
 ;一部のキャラは性別を選択する
-SIF 対象 != 0
+SIF (データID != 0) && (対象 != 0)
 	CALL 性別選択, TARGET
 
 IF !クローニング


### PR DESCRIPTION
CSVエディタで性別不明の既存キャラを読み込んだ際、強制的に性別が設定されてしまう現象を修正。
